### PR TITLE
remove unnecessary npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "node": ">=8"
   },
   "dependencies": {
-    "braintreehttp": "^0.4.0",
-    "npm": "^6.4.0"
+    "braintreehttp": "^0.4.0"
   },
   "devDependencies": {
     "btoa": "^1.2.1",


### PR DESCRIPTION
Fixes #15.

Having `npm` listed as a dependency is unnecessary and can be removed as a dependency. If it's necessary as a dev dependency, I'm happy to add it there, but I don't have a compelling reason for it to exist. When looking through the history, it looks like it may have been added so that it was available to the `node_modules` (at one point `node_modules` was version controlled).
